### PR TITLE
Improve resiliency of the GithubSearchTest

### DIFF
--- a/bdd4j-example-calculator/src/test/java/org/bdd4j/example/calculator/CalculatorScenarioTest.java
+++ b/bdd4j-example-calculator/src/test/java/org/bdd4j/example/calculator/CalculatorScenarioTest.java
@@ -1,17 +1,14 @@
 package org.bdd4j.example.calculator;
 
 import org.bdd4j.BDD4jRunner;
-import org.bdd4j.BDD4jTest;
 import org.bdd4j.Feature;
 import org.bdd4j.Scenario;
 import org.bdd4j.UserStory;
-import org.junit.jupiter.api.Test;
 
 
 /**
  * A scenario based test for the very complex calculator.
  */
-@BDD4jTest
 @Feature("Very complex calculator")
 @UserStory("""
     As a mathematician
@@ -21,7 +18,6 @@ import org.junit.jupiter.api.Test;
 public class CalculatorScenarioTest
 {
   @Scenario("Add a value")
-  @Test
   public void addAValue(final CalculatorSteps steps)
   {
     BDD4jRunner.scenario(steps, steps.givenThatIHaveABlankCalculator(),
@@ -29,7 +25,6 @@ public class CalculatorScenarioTest
   }
 
   @Scenario("Subtract a value")
-  @Test
   public void subtractAValue(final CalculatorSteps steps)
   {
     BDD4jRunner.scenario(steps, steps.givenThatIHaveABlankCalculator(),
@@ -38,7 +33,6 @@ public class CalculatorScenarioTest
   }
 
   @Scenario("Clear")
-  @Test
   public void clear(final CalculatorSteps steps)
   {
     BDD4jRunner.scenario(steps, steps.givenThatIHaveABlankCalculator(),
@@ -47,7 +41,6 @@ public class CalculatorScenarioTest
   }
 
   @Scenario("Integer overflow")
-  @Test
   public void integerOverflow(final CalculatorSteps steps)
   {
     BDD4jRunner.scenario(steps, steps.givenThatIHaveABlankCalculator(),
@@ -57,7 +50,6 @@ public class CalculatorScenarioTest
   }
 
   @Scenario("Integer underflow")
-  @Test
   public void integerUnderflow(final CalculatorSteps steps)
   {
     BDD4jRunner.scenario(steps, steps.givenThatIHaveABlankCalculator(),

--- a/bdd4j-example-selenium/src/test/java/org/bdd4j/example/selenium/GithubPageObject.java
+++ b/bdd4j-example-selenium/src/test/java/org/bdd4j/example/selenium/GithubPageObject.java
@@ -77,7 +77,7 @@ public class GithubPageObject implements AutoCloseable
    * {@inheritDoc}
    */
   @Override
-  public void close() throws Exception
+  public void close()
   {
     container.close();
   }

--- a/bdd4j-example-selenium/src/test/java/org/bdd4j/example/selenium/GithubSearchResultPageObject.java
+++ b/bdd4j-example-selenium/src/test/java/org/bdd4j/example/selenium/GithubSearchResultPageObject.java
@@ -27,18 +27,18 @@ public class GithubSearchResultPageObject
   /**
    * Checks whether the page contains the given URL.
    *
-   * @param url The URL that should be checked.
+   * @param expectedURL The URL that should be checked.
    */
-  public void shouldContainALinkTo(final String url)
+  public void shouldContainALinkTo(final String expectedURL)
   {
     for (final WebElement link : driver.findElements(By.tagName("a")))
     {
-      if (Objects.equals(link.getAttribute("href"), url))
+      if (Objects.equals(link.getAttribute("href"), expectedURL))
       {
         return;
       }
     }
 
-    Assertions.fail("Missing link to " + url);
+    Assertions.fail("Missing link to " + expectedURL);
   }
 }

--- a/bdd4j-example-selenium/src/test/java/org/bdd4j/example/selenium/GithubSearchSteps.java
+++ b/bdd4j-example-selenium/src/test/java/org/bdd4j/example/selenium/GithubSearchSteps.java
@@ -1,15 +1,12 @@
 package org.bdd4j.example.selenium;
 
-import static org.bdd4j.StepDSL.given;
 import static org.bdd4j.StepDSL.then;
 import static org.bdd4j.StepDSL.when;
 
 import org.bdd4j.BDD4jSteps;
-import org.bdd4j.Given;
 import org.bdd4j.TestState;
 import org.bdd4j.Then;
 import org.bdd4j.When;
-import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.testcontainers.containers.BrowserWebDriverContainer;
 
@@ -33,9 +30,9 @@ public class GithubSearchSteps implements BDD4jSteps<GithubPageObject>
     return TestState.state(new GithubPageObject(container));
   }
 
-  public Given<GithubPageObject> givenThatIOpenTheLandingPage()
+  public When<GithubPageObject> whenIOpenTheLandingPage()
   {
-    return given("that I open the landing page").step(state -> {
+    return when("I open the landing page").step(state -> {
       state.openLandingPage();
 
       return TestState.state(state);
@@ -44,7 +41,7 @@ public class GithubSearchSteps implements BDD4jSteps<GithubPageObject>
 
   public When<GithubPageObject> whenIEnterTheSearchTerm(final String searchTerm)
   {
-    return when("I enter the search term '{0}'", searchTerm).step(state -> {
+    return when("I enter the search term ''{0}''", searchTerm).step(state -> {
       state.landingPage().enterSearchTerm(searchTerm);
 
       return TestState.state(state);
@@ -60,10 +57,10 @@ public class GithubSearchSteps implements BDD4jSteps<GithubPageObject>
     });
   }
 
-  public Then<GithubPageObject> thenIShouldFindTheLinkToTheBdd4jProject()
+  public Then<GithubPageObject> thenIShouldFindALinkTo(final String expectedLink)
   {
-    return then("I should find the link to the bdd4j project").step(state -> {
-      state.state().searchResultsPage().shouldContainALinkTo("https://github.com/bdd4j/bdd4j");
+    return then("I should find the link to ''{0}''", expectedLink).step(state -> {
+      state.state().searchResultsPage().shouldContainALinkTo(expectedLink);
       return state;
     });
   }
@@ -72,6 +69,13 @@ public class GithubSearchSteps implements BDD4jSteps<GithubPageObject>
   {
     return then("I should be on the search results page").step(state -> {
       state.state().shouldBeOnTheURL("https://github.com/search?q=bdd4j&type=");
+      try
+      {
+        state.state().wait();
+      } catch (final InterruptedException e)
+      {
+        throw new RuntimeException(e);
+      }
 
       return state;
     });

--- a/bdd4j-example-selenium/src/test/java/org/bdd4j/example/selenium/GithubSearchTest.java
+++ b/bdd4j-example-selenium/src/test/java/org/bdd4j/example/selenium/GithubSearchTest.java
@@ -1,13 +1,10 @@
 package org.bdd4j.example.selenium;
 
 import org.bdd4j.BDD4jRunner;
-import org.bdd4j.BDD4jTest;
 import org.bdd4j.Feature;
 import org.bdd4j.Scenario;
 import org.bdd4j.UserStory;
-import org.junit.jupiter.api.Test;
 
-@BDD4jTest
 @Feature("Search for github projects")
 @UserStory("""
     As an anonymous user
@@ -17,14 +14,13 @@ import org.junit.jupiter.api.Test;
 public class GithubSearchTest
 {
   @Scenario("Search for 'bdd4j'")
-  @Test
   public void searchForBDD4j(final GithubSearchSteps steps)
   {
     BDD4jRunner.scenario(steps,
-        steps.givenThatIOpenTheLandingPage(),
+        steps.whenIOpenTheLandingPage(),
         steps.whenIEnterTheSearchTerm("bdd4j"),
         steps.whenIHitTheEnterKey(),
         steps.thenIShouldBeOnTheSearchResultsPage(),
-        steps.thenIShouldFindTheLinkToTheBdd4jProject());
+        steps.thenIShouldFindALinkTo("https://github.com/bdd4j/bdd4j"));
   }
 }

--- a/bdd4j-junit5/src/main/java/org/bdd4j/BDD4jRunner.java
+++ b/bdd4j-junit5/src/main/java/org/bdd4j/BDD4jRunner.java
@@ -24,10 +24,10 @@ public class BDD4jRunner
   @SafeVarargs
   public static <T> void scenario(final BDD4jSteps<T> stepsWrapper, final Step<T>... steps)
   {
-    final TestStepVisitor<T> stepVisitor = new TestStepVisitor<>(stepsWrapper.init());
-
-    try
+    try (final TestState<T> state = stepsWrapper.init())
     {
+      final TestStepVisitor<T> stepVisitor = new TestStepVisitor<>(state);
+
       publishEvent(new ScenarioTestStartedEvent(LocalDateTime.now(), steps.length,
           "TODO: Determine the actual name of the scenario"));
 
@@ -62,18 +62,9 @@ public class BDD4jRunner
           throw new AssertionError("Failed to execute the scenario", e);
         }
       }
-    } finally
+    } catch (final Exception e)
     {
-      if (stepVisitor.currentState() instanceof AutoCloseable closeable)
-      {
-        try
-        {
-          closeable.close();
-        } catch (final Exception e)
-        {
-          throw new RuntimeException(e);
-        }
-      }
+      throw new RuntimeException(e);
     }
   }
 

--- a/bdd4j-junit5/src/main/java/org/bdd4j/BDD4jTest.java
+++ b/bdd4j-junit5/src/main/java/org/bdd4j/BDD4jTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(BDD4jParameterResolver.class)
 @ExtendWith(BDD4jTestWatcher.class)
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE)
+@Target(ElementType.ANNOTATION_TYPE)
 public @interface BDD4jTest
 {
 }

--- a/bdd4j-junit5/src/main/java/org/bdd4j/Given.java
+++ b/bdd4j-junit5/src/main/java/org/bdd4j/Given.java
@@ -19,4 +19,21 @@ public record Given<T>(String description, Function<T, TestState<T>> logic) impl
   {
     visitor.visit(this);
   }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public TestState<T> applyLogic(final TestState<T> state) throws Throwable
+  {
+    state.raiseExceptionIfPresent();
+
+    try
+    {
+      return logic().apply(state.state());
+    } catch (final Throwable exception)
+    {
+      return TestState.exception(exception);
+    }
+  }
 }

--- a/bdd4j-junit5/src/main/java/org/bdd4j/Scenario.java
+++ b/bdd4j-junit5/src/main/java/org/bdd4j/Scenario.java
@@ -5,11 +5,15 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.junit.jupiter.api.Test;
+
 /**
  * An annotation that can be used to describe a scenario.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
+@Test
+@BDD4jTest
 public @interface Scenario
 {
   /**

--- a/bdd4j-junit5/src/main/java/org/bdd4j/Step.java
+++ b/bdd4j-junit5/src/main/java/org/bdd4j/Step.java
@@ -21,4 +21,13 @@ public interface Step<T>
    * @throws Throwable Might throw any kind of exception.
    */
   void accept(final StepVisitor<T> visitor) throws Throwable;
+
+  /**
+   * Applies the logic of the step to the given state.
+   *
+   * @param state The state.
+   * @return The result of the applied logic.
+   * @throws Throwable Might throw any kind of exception based on the steps logic.
+   */
+  TestState<T> applyLogic(final TestState<T> state) throws Throwable;
 }

--- a/bdd4j-junit5/src/main/java/org/bdd4j/StepDSL.java
+++ b/bdd4j-junit5/src/main/java/org/bdd4j/StepDSL.java
@@ -28,7 +28,7 @@ public class StepDSL
    */
   public static GivenBuilder given(final String template, final Object... args)
   {
-    return given(MessageFormat.format(template, args));
+    return given(formatStepName(template, args));
   }
 
   /**
@@ -51,7 +51,7 @@ public class StepDSL
    */
   public static WhenBuilder when(final String template, final Object... args)
   {
-    return when(MessageFormat.format(template, args));
+    return when(formatStepName(template, args));
   }
 
   /**
@@ -74,7 +74,20 @@ public class StepDSL
    */
   public static ThenBuilder then(final String template, final Object... args)
   {
-    return then(MessageFormat.format(template, args));
+    return then(formatStepName(template, args));
+  }
+
+  /**
+   * Formats the given step name template with the given arguments.
+   *
+   * @param template The template string.
+   * @param args     The arguments.
+   * @return The formatted name template.
+   */
+  private static String formatStepName(final String template,
+                                       final Object[] args)
+  {
+    return MessageFormat.format(template, args);
   }
 
   /**

--- a/bdd4j-junit5/src/main/java/org/bdd4j/StepVisitor.java
+++ b/bdd4j-junit5/src/main/java/org/bdd4j/StepVisitor.java
@@ -8,13 +8,6 @@ package org.bdd4j;
 public interface StepVisitor<T>
 {
   /**
-   * Retrieves the current state.
-   *
-   * @return The current state.
-   */
-  T currentState();
-
-  /**
    * Visits the given step.
    *
    * @param step The step.
@@ -33,5 +26,5 @@ public interface StepVisitor<T>
    *
    * @param step The step.
    */
-  void visit(Then<T> step);
+  void visit(Then<T> step) throws Throwable;
 }

--- a/bdd4j-junit5/src/main/java/org/bdd4j/TestState.java
+++ b/bdd4j-junit5/src/main/java/org/bdd4j/TestState.java
@@ -7,7 +7,7 @@ package org.bdd4j;
  * @param exception An optional exception that has been thrown by a previous step.
  * @param <T>       The type of the test state.
  */
-public record TestState<T>(T state, Throwable exception)
+public record TestState<T>(T state, Throwable exception) implements AutoCloseable
 {
   /**
    * Creates a new test state with the given state.
@@ -53,5 +53,40 @@ public record TestState<T>(T state, Throwable exception)
   public TestState<T> withState(final T state)
   {
     return new TestState<>(state, exception);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void close() throws Exception
+  {
+    if (state != null && state instanceof AutoCloseable autoClosable)
+    {
+      autoClosable.close();
+    }
+  }
+
+  /**
+   * Checks whether the test state has an exception in store.
+   *
+   * @return True if the test state has an exception, otherwise false.
+   */
+  public boolean hasException()
+  {
+    return exception != null;
+  }
+
+  /**
+   * Raises the stored exception if it is present.
+   *
+   * @throws Throwable Might throw any kind of stored exception.
+   */
+  public void raiseExceptionIfPresent() throws Throwable
+  {
+    if (hasException())
+    {
+      throw exception;
+    }
   }
 }

--- a/bdd4j-junit5/src/main/java/org/bdd4j/TestStepVisitor.java
+++ b/bdd4j-junit5/src/main/java/org/bdd4j/TestStepVisitor.java
@@ -7,7 +7,6 @@ package org.bdd4j;
  */
 public final class TestStepVisitor<T> implements StepVisitor<T>
 {
-
   private TestState<T> state;
 
   /**
@@ -24,29 +23,9 @@ public final class TestStepVisitor<T> implements StepVisitor<T>
    * {@inheritDoc}
    */
   @Override
-  public T currentState()
-  {
-    return state.state();
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
   public void visit(final Given<T> step) throws Throwable
   {
-    if (state.exception() != null)
-    {
-      throw state.exception();
-    }
-
-    try
-    {
-      state = step.logic().apply(state.state());
-    } catch (final Throwable exception)
-    {
-      state = TestState.exception(exception);
-    }
+    state = step.applyLogic(state);
   }
 
   /**
@@ -55,35 +34,15 @@ public final class TestStepVisitor<T> implements StepVisitor<T>
   @Override
   public void visit(final When<T> step) throws Throwable
   {
-    if (state.exception() != null)
-    {
-      throw state.exception();
-    }
-
-    try
-    {
-      state = step.logic().apply(state.state());
-    } catch (final Throwable exception)
-    {
-      state = TestState.exception(exception);
-    }
+    state = step.applyLogic(state);
   }
 
   /**
    * {@inheritDoc}
    */
   @Override
-  public void visit(final Then<T> step)
+  public void visit(final Then<T> step) throws Throwable
   {
-    try
-    {
-      state = step.logic().apply(state);
-    } catch (final AssertionError assertionError)
-    {
-      throw assertionError;
-    } catch (final Throwable exception)
-    {
-      state = TestState.exception(exception);
-    }
+    state = step.applyLogic(state);
   }
 }

--- a/bdd4j-junit5/src/main/java/org/bdd4j/Then.java
+++ b/bdd4j-junit5/src/main/java/org/bdd4j/Then.java
@@ -16,8 +16,26 @@ public record Then<T>(String description, Function<TestState<T>, TestState<T>> l
    * {@inheritDoc}
    */
   @Override
-  public void accept(final StepVisitor<T> visitor)
+  public void accept(final StepVisitor<T> visitor) throws Throwable
   {
     visitor.visit(this);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public TestState<T> applyLogic(TestState<T> state)
+  {
+    try
+    {
+      return logic().apply(state);
+    } catch (final AssertionError assertionError)
+    {
+      throw assertionError;
+    } catch (final Throwable exception)
+    {
+      return TestState.exception(exception);
+    }
   }
 }

--- a/bdd4j-junit5/src/main/java/org/bdd4j/When.java
+++ b/bdd4j-junit5/src/main/java/org/bdd4j/When.java
@@ -19,4 +19,21 @@ public record When<T>(String description, Function<T, TestState<T>> logic) imple
   {
     visitor.visit(this);
   }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public TestState<T> applyLogic(final TestState<T> state) throws Throwable
+  {
+    state.raiseExceptionIfPresent();
+
+    try
+    {
+      return logic().apply(state.state());
+    } catch (final Throwable exception)
+    {
+      return TestState.exception(exception);
+    }
+  }
 }

--- a/bdd4j-junit5/src/test/java/org/bdd4j/StepDSLTest.java
+++ b/bdd4j-junit5/src/test/java/org/bdd4j/StepDSLTest.java
@@ -1,0 +1,20 @@
+package org.bdd4j;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class StepDSLTest
+{
+
+  @Test
+  public void when_withMessageFormat()
+  {
+    final var step =
+        StepDSL.when("I pass ''{0}'' they should be rendered properly", "parameters")
+            .step(TestState::state);
+
+    assertThat(step.description()).isEqualTo(
+        "I pass 'parameters' they should be rendered properly");
+  }
+}


### PR DESCRIPTION
This change also changed the way annotations like @Scenario and @BDD4jTest are used. @BDD4jTest is now a meta annotation and @Scenario is annotated with it. As @Scenario is now also meta annotated with the @Test annotation, only the @Scenario annotation has to be present when defining a test scenario.

This commit also changes a few of the internals as to how the framework processes the TestState and improves resource handling.

https://github.com/bdd4j/bdd4j/issues/8